### PR TITLE
fixes single/static object reference

### DIFF
--- a/sakstig/ast.py
+++ b/sakstig/ast.py
@@ -142,18 +142,19 @@ class AST(object):
         return ast_base_types.Op(self, "filter", path, *filters)
 
 def compile(query, **args):
-    tree = grammar.grammar.parse(query)
+    gramr = grammar.SakstigGrammar()
+    tree = gramr.parse(query)
     if not tree.is_valid:
         raise SyntaxError("Malformed query: %s<ERROR>%s\n%s" % (
             query[:tree.pos],
             query[tree.pos:],
-            grammar.format_tree(tree.tree)))
+            gramr.format_tree(tree.tree)))
     return AST(tree.tree, **args)
     
 def main():
     from . import grammar
     import sys
-    res = grammar.grammar.parse(sys.argv[1])
+    res = grammar.SakstigGrammar().parse(sys.argv[1])
     if not res.is_valid:
         print("INVALID EXPRESSION")
     else:

--- a/sakstig/grammar.py
+++ b/sakstig/grammar.py
@@ -81,10 +81,7 @@ class SakstigGrammar(Grammar):
     NO_COMMA_START = Sequence(bool)    
     START = Sequence(union)
 
-    
-grammar = SakstigGrammar()
 
-        
 def format_tree(node, indent=''):
     if len(node.children) == 1:
         return format_tree(node.children[0], indent)
@@ -96,7 +93,7 @@ def format_tree(node, indent=''):
 
 def main():
     import sys
-    res = grammar.parse(sys.argv[1])
+    res = SakstigGrammar().parse(sys.argv[1])
     if not res.is_valid:
         print("INVALID EXPRESSION")
     else:


### PR DESCRIPTION
referring to a single object causes threading issues; 
One thread enters the ast `parse` function sets values to `self`, meanwhile a second thread enters `parse` on the same object and changes the values set on `self`. The first thread does a calculation using both values and fails, eventually resulting in a `SyntaxError`