### PR TITLE
`str(query_set)` returns extra quotes, this adds __str__ to queryset to prevent that

### DIFF
--- a/sakstig/queryset.py
+++ b/sakstig/queryset.py
@@ -4,9 +4,15 @@ class QuerySet(list):
     def __init__(self, *arg, **kw):
         list.__init__(self, *arg, **kw)
         self.is_path_multi = False
-        
+
     def __repr__(self):
         return "%s\n" % ("\n".join(repr(item) for item in self))
+
+    def __str__(self):
+        if len(self) == 1:
+            return str(self[0])
+        else:
+            return super().__str__(self)
 
     def execute(self, query, global_qs = None, **args):
         from . import ast


### PR DESCRIPTION
before:
```python
>>> import sakstig
>>> qs = sakstig.QuerySet([{"name": "alice", "sequence":1}]).execute("$.name")
>>> str(qs) == list(qs)[0]
False
>>> str(qs) == "'alice'"
True
>>> list(qs)[0] == "alice"
True
```
after:
```python
>>> import sakstig
>>> qs = sakstig.QuerySet([{"name": "alice", "sequence":1}]).execute("$.name")
>>> str(qs) == list(qs)[0]
True
>>> repr(qs) == "'alice'"
True
```